### PR TITLE
Post C99 inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arena Allocator
-Single-header arena allocator written in C89
+Single-header arena allocator. C89 Compatible.
 
 ---
 

--- a/arena.h
+++ b/arena.h
@@ -30,6 +30,11 @@ QUICK USAGE:
 
 #include <stddef.h>
 
+#if __STDC_VERSION__ >= 199901L
+    #define inline inline
+#else
+    #define inline
+#endif
 
 #ifdef ARENA_DEBUG
 

--- a/arena.h
+++ b/arena.h
@@ -30,11 +30,13 @@ QUICK USAGE:
 
 #include <stddef.h>
 
+
 #if __STDC_VERSION__ >= 199901L
     #define ARENA_INLINE inline
 #else
     #define ARENA_INLINE
 #endif
+
 
 #ifdef ARENA_DEBUG
 

--- a/arena.h
+++ b/arena.h
@@ -31,9 +31,9 @@ QUICK USAGE:
 #include <stddef.h>
 
 #if __STDC_VERSION__ >= 199901L
-    #define inline inline
+    #define ARENA_INLINE inline
 #else
-    #define inline
+    #define ARENA_INLINE
 #endif
 
 #ifdef ARENA_DEBUG


### PR DESCRIPTION
Small block of preprocessor to allow for functions to be marked `inline` in future features. Still C89 compatible. `inline` is supported by C99 and newer standards.