### PR TITLE
Issue #7 `arena_copy` feature request and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ For one file in one translation unit, you need to define some macros before incl
 ```c
 #define ARENA_IMPLEMENTATION
 
-// You will get a warning if you don't specify:
-// either both of these...
-#define ARENA_MALLOC <stdlib_malloc_like_allocator> // defaults to stdlib malloc
-#define ARENA_FREE <stdlib_free_like_deallocator>   // defaults to stdlib free
-// ... or just this
-#define ARENA_SUPPRESS_MALLOC_WARN // Alternatively use compiler flag -DARENA_SUPPRESS_MALLOC_WARN
+// All of these are optional
+#define ARENA_MALLOC <stdlib_malloc_like_allocator>
+#define ARENA_FREE <stdlib_free_like_deallocator>
+#define ARENA_MEMCPY <stdlib_memcpy_like_copier>
 
-#include "arena.h"
+// for debug functionality, you can also do:
+#define ARENA_DEBUG
 ```
 
 After doing this in **one** file in **one** translation unit, for **any other file** you can include normally with a lone `#include "arena.h"`.

--- a/arena.h
+++ b/arena.h
@@ -5,16 +5,15 @@ example.
 QUICK USAGE:
   One file in one translation unit must have the
   following before including "arena.h", replacing
-  the macro values appropriately when needed.
+  the macro values appropriately when desired.
 
 ```
 #define ARENA_IMPLEMENTATION
 
-// Either both of these...
+// All of these are optional
 #define ARENA_MALLOC <stdlib_malloc_like_allocator>
 #define ARENA_FREE <stdlib_free_like_deallocator>
-// ... or just this
-#define ARENA_SUPPRESS_MALLOC_WARN // alternatively using compiler flag -D with same name
+#define ARENA_MEMCPY <stdlib_memcpy_like_copier>
 
 // for debug functionality, you can also do:
 #define ARENA_DEBUG
@@ -183,20 +182,20 @@ Arena_Allocation* arena_get_allocation_struct(Arena *arena, void *ptr);
 #ifdef ARENA_IMPLEMENTATION
 
 
-#if !defined(ARENA_MALLOC) || !defined(ARENA_FREE) || !defined(ARENA_MEMCPY)
-
-    #ifndef ARENA_SUPPRESS_MALLOC_WARN
-        #warning "Using <stdlib.h> malloc and free, because a replacement for one or both was not specified before including 'arena.h'."
-    #endif /* !ARENA_SUPPRESS_MALLOC_WARN */
-
+#ifndef ARENA_MALLOC
     #include <stdlib.h>
     #define ARENA_MALLOC malloc
-    #define ARENA_FREE free
+#endif
 
+#ifndef ARENA_FREE
+    #include <stdlib.h>
+    #define ARENA_FREE free
+#endif
+
+#ifndef ARENA_MEMCPY
     #include <string.h>
     #define ARENA_MEMCPY memcpy
-
-#endif /* !defined ARENA_MALLOC, ARENA_FREE */
+#endif
 
 
 Arena* arena_create(size_t size)

--- a/arena.h
+++ b/arena.h
@@ -131,6 +131,17 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment);
 
 
 /*
+Copy the memory contents of one arena to another.
+
+Parameters:
+  Arena *src     |    The arena being copied, the source.
+  Arena *dest    |    The arena being copied to. Must be created/allocated
+                      already.
+*/
+ARENA_INLINE void arena_copy(Arena *src, Arena *dest);
+
+
+/*
 Reset the pointer to the arena region to the beginning
 of the allocation. Allows reuse of the memory without
 realloc or frees.
@@ -172,7 +183,7 @@ Arena_Allocation* arena_get_allocation_struct(Arena *arena, void *ptr);
 #ifdef ARENA_IMPLEMENTATION
 
 
-#if !defined(ARENA_MALLOC) || !defined(ARENA_FREE)
+#if !defined(ARENA_MALLOC) || !defined(ARENA_FREE) || !defined(ARENA_MEMCPY)
 
     #ifndef ARENA_SUPPRESS_MALLOC_WARN
         #warning "Using <stdlib.h> malloc and free, because a replacement for one or both was not specified before including 'arena.h'."
@@ -181,6 +192,9 @@ Arena_Allocation* arena_get_allocation_struct(Arena *arena, void *ptr);
     #include <stdlib.h>
     #define ARENA_MALLOC malloc
     #define ARENA_FREE free
+
+    #include <string.h>
+    #define ARENA_MEMCPY memcpy
 
 #endif /* !defined ARENA_MALLOC, ARENA_FREE */
 
@@ -288,6 +302,12 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
     }
 
     return arena_alloc(arena, size);
+}
+
+
+ARENA_INLINE void arena_copy(Arena *src, Arena *dest)
+{
+    ARENA_MEMCPY(dest->region, src->region, src->index);
 }
 
 

--- a/arena.h
+++ b/arena.h
@@ -311,7 +311,7 @@ ARENA_INLINE void arena_copy(Arena *dest, Arena *src)
 }
 
 
-void arena_clear(Arena *arena)
+ARENA_INLINE void arena_clear(Arena *arena)
 {
     if(arena == NULL)
     {

--- a/arena.h
+++ b/arena.h
@@ -307,7 +307,6 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
 ARENA_INLINE void arena_copy(Arena *dest, Arena *src)
 {
     ARENA_MEMCPY(dest->region, src->region, src->index);
-    dest->size = src->size;
     dest->index = src->index;
 }
 

--- a/arena.h
+++ b/arena.h
@@ -307,6 +307,8 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
 ARENA_INLINE void arena_copy(Arena *src, Arena *dest)
 {
     ARENA_MEMCPY(dest->region, src->region, src->index);
+    dest->size = src->size;
+    dest->index = src->index;
 }
 
 

--- a/arena.h
+++ b/arena.h
@@ -226,12 +226,7 @@ Arena* arena_create(size_t size)
 
 void* arena_alloc(Arena *arena, size_t size)
 {
-    if(arena == NULL)
-    {
-        return NULL;
-    }
-
-    if(arena->region == NULL)
+    if(arena == NULL || arena->region == NULL)
     {
         return NULL;
     }
@@ -279,12 +274,7 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
 {
     unsigned int offset;
 
-    if(arena == NULL)
-    {
-        return NULL;
-    }
-
-    if(arena->region == NULL)
+    if(arena == NULL || arena->region == NULL)
     {
         return NULL;
     }
@@ -306,6 +296,10 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
 
 ARENA_INLINE void arena_copy(Arena *dest, Arena *src)
 {
+    if(dest == NULL || src == NULL)
+    {
+        return;
+    }
     ARENA_MEMCPY(dest->region, src->region, src->index);
     dest->index = src->index;
 }

--- a/arena.h
+++ b/arena.h
@@ -137,7 +137,7 @@ Parameters:
   Arena *dest    |    The arena being copied to. Must be created/allocated
                       already.
 */
-ARENA_INLINE void arena_copy(Arena *src, Arena *dest);
+ARENA_INLINE void arena_copy(Arena *dest, Arena *src);
 
 
 /*
@@ -304,7 +304,7 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
 }
 
 
-ARENA_INLINE void arena_copy(Arena *src, Arena *dest)
+ARENA_INLINE void arena_copy(Arena *dest, Arena *src)
 {
     ARENA_MEMCPY(dest->region, src->region, src->index);
     dest->size = src->size;

--- a/code_examples/example.c
+++ b/code_examples/example.c
@@ -2,7 +2,6 @@
 #include <string.h> // memcpy
 
 #define ARENA_IMPLEMENTATION
-#define ARENA_SUPPRESS_MALLOC_WARN
 #include "../arena.h"
 
 int main(void)

--- a/code_examples/example_aligned.c
+++ b/code_examples/example_aligned.c
@@ -1,7 +1,6 @@
 #include <stdio.h>  // printf
 
 #define ARENA_IMPLEMENTATION
-#define ARENA_SUPPRESS_MALLOC_WARN
 #include "../arena.h"
 
 int main(void)

--- a/code_examples/example_debug.c
+++ b/code_examples/example_debug.c
@@ -3,7 +3,6 @@
 
 #define ARENA_DEBUG
 #define ARENA_IMPLEMENTATION
-#define ARENA_SUPPRESS_MALLOC_WARN
 #include "../arena.h"
 
 int main(void)

--- a/test.c
+++ b/test.c
@@ -125,9 +125,9 @@ void test_arena_alloc(void)
 {
     Arena *arena = arena_create(13 + sizeof(long) * 3);
     char *char_array = arena_alloc(arena, 13);
-    long *long_array = arena_alloc(arena, sizeof(long) * 3);
+    long *long_array;
     long expected_long_array[3] = {999, 9999, 99999};
-    char *should_not_be_allocated = arena_alloc(arena, 1);
+    char *should_not_be_allocated;
 
     TEST_FATAL(char_array != NULL, "char array allocated from arena was NULL.");
     TEST_FATAL(arena->head_allocation != NULL, "Arena's head allocation linked list node was NULL.");
@@ -153,6 +153,7 @@ void test_arena_alloc(void)
 
     TEST_EQUAL(arena->index, 13);
 
+    long_array = arena_alloc(arena, sizeof(long) * 3);
     TEST_FATAL(long_array != NULL, "long array allocated from arena was NULL.");
 
     TEST_FATAL(arena->head_allocation->next != NULL, "Link list addition failed.");
@@ -171,6 +172,7 @@ void test_arena_alloc(void)
     
     TEST_EQUAL(arena_alloc(NULL, 0), NULL);
 
+    should_not_be_allocated = arena_alloc(arena, 1);
     TEST_EQUAL(should_not_be_allocated, NULL);
 
     arena_destroy(arena);

--- a/test.c
+++ b/test.c
@@ -90,6 +90,7 @@ static int temp_total;
 void test_arena_create(void);
 void test_arena_alloc(void);
 void test_arena_alloc_aligned(void);
+void test_arena_copy(void);
 void test_arena_clear(void);
 void test_arena_get_allocation_struct(void);
 
@@ -99,6 +100,7 @@ int main(void)
     REPORT(test_arena_create, "Arena creation suite");
     REPORT(test_arena_alloc, "Arena unaligned allocation suite");
     REPORT(test_arena_alloc_aligned, "Arena aligned allocation suite");
+    REPORT(test_arena_copy, "Arena copy suite");
     REPORT(test_arena_clear, "Arena clearing suite");
     REPORT(test_arena_get_allocation_struct, "Arena debug method 'arena_get_allocation_struct' suite");
 
@@ -203,6 +205,30 @@ void test_arena_alloc_aligned(void)
     TEST_EQUAL(arena->allocations, 5);
 
     arena_destroy(arena);
+}
+
+
+void test_arena_copy(void)
+{
+    Arena *arena_src = arena_create(1024);
+    Arena *arena_dest = arena_create(1024);
+    char *src_array;
+
+    TEST_FATAL(arena_src != NULL, "Source arena creation failed!");
+    TEST_FATAL(arena_dest != NULL, "Destination arena creation failed!");
+
+    src_array = arena_alloc(arena_src, 3);
+    TEST_FATAL(src_array != NULL, "Source arena allocation failed!");
+    src_array[0] = 'a';
+    src_array[1] = 'b';
+    src_array[2] = 'c';
+    arena_copy(arena_dest, arena_src);
+    TEST_EQUAL(arena_dest->region[0], 'a');
+    TEST_EQUAL(arena_dest->region[1], 'b');
+    TEST_EQUAL(arena_dest->region[2], 'c');
+    TEST_EQUAL(arena_dest->index, 3);
+    arena_destroy(arena_src);
+    arena_destroy(arena_dest);
 }
 
 


### PR DESCRIPTION
This adds a feature mentioned in #7 for copying an arena. It is essentially a wrapper for `memcpy`. There were some additional changes as well, such as improved C89 compliance for `test.c` and deprecation of the `ARENA_SUPPRESS_MALLOC_WARN` macro.

This passed all tests and did not show any leaks under valgrind.