### PR TITLE
Default alignment and reworked testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ For one file in one translation unit, you need to define some macros before incl
 
 // for debug functionality, you can also do:
 #define ARENA_DEBUG
+
+// If you would like to change the default alignment for
+// allocations, you can define:
+#define ARENA_DEFAULT_ALIGNMENT <alignment_value>
 ```
 
 After doing this in **one** file in **one** translation unit, for **any other file** you can include normally with a lone `#include "arena.h"`. You can find usage examples in the [`code_examples/` folder](https://github.com/ccgargantua/arena-allocator/tree/main/code_examples).
@@ -111,8 +115,10 @@ Return a pointer to a portion of specified size of the
 specified arena's region. Nothing will restrict you
 from allocating more memory than you specified, so be
 mindful of your memory (as you should anyways) or you
-will get some hard-to-track bugs. Providing a size of
-zero results in a failure.
+will get some hard-to-track bugs. By default, memory is
+aligned by sizeof(size_t), but you can change this by
+#defining ARENA_DEFAULT_ALIGNMENT before #include'ing
+arena.h. Providing a size of zero results in a failure.
 
 Parameters:
   Arena *arena    |    The arena of which the pointer
@@ -125,12 +131,12 @@ Return:
   Pointer to arena region segment on success, NULL on
   failure.
 */
-void* arena_alloc(Arena *arena, size_t size);
+ARENA_INLINE void* arena_alloc(Arena *arena, size_t size);
 
 
 /*
-Same as arena_alloc, except you can specify a
-memory alignment for allocations.
+Same as arena_alloc, except you can specify a memory
+alignment for allocations.
 
 Return a pointer to a portion of specified size of the
 specified arena's region. Nothing will restrict you
@@ -189,8 +195,7 @@ void arena_destroy(Arena *arena);
 /*
 Returns a pointer to the allocation struct associated
 with a pointer to a segment in the specified arena's
-region. This function is only available when ARENA_DEBUG
-is defined.
+region.
 
 Parameters:
   Arena *arena    |    The arena whose region should

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ specified arena's region. Nothing will restrict you
 from allocating more memory than you specified, so be
 mindful of your memory (as you should anyways) or you
 will get some hard-to-track bugs. By default, memory is
-aligned by sizeof(size_t), but you can change this by
+aligned by alignof(size_t), but you can change this by
 #defining ARENA_DEFAULT_ALIGNMENT before #include'ing
 arena.h. Providing a size of zero results in a failure.
 

--- a/arena.h
+++ b/arena.h
@@ -17,6 +17,10 @@ QUICK USAGE:
 
 // for debug functionality, you can also do:
 #define ARENA_DEBUG
+
+// If you would like to change the default alignment for
+// allocations, you can define:
+#define ARENA_DEFAULT_ALIGNMENT <alignment_value>
 ```
 
   After doing that, you can `#include "arena.h"`

--- a/arena.h
+++ b/arena.h
@@ -101,8 +101,10 @@ Return a pointer to a portion of specified size of the
 specified arena's region. Nothing will restrict you
 from allocating more memory than you specified, so be
 mindful of your memory (as you should anyways) or you
-will get some hard-to-track bugs. Providing a size of
-zero results in a failure.
+will get some hard-to-track bugs. By default, memory is
+aligned by sizeof(size_t), but you can change this by
+#defining ARENA_DEFAULT_ALIGNMENT before #include'ing
+arena.h. Providing a size of zero results in a failure.
 
 Parameters:
   Arena *arena    |    The arena of which the pointer
@@ -119,8 +121,8 @@ ARENA_INLINE void* arena_alloc(Arena *arena, size_t size);
 
 
 /*
-Same as arena_alloc, except you can specify a
-memory alignment for allocations.
+Same as arena_alloc, except you can specify a memory
+alignment for allocations.
 
 Return a pointer to a portion of specified size of the
 specified arena's region. Nothing will restrict you

--- a/arena.h
+++ b/arena.h
@@ -47,9 +47,11 @@ QUICK USAGE:
     #define ARENA_ALIGNOF(type) offsetof(struct { char c; type d; }, d)
 #endif
 
+
 #ifndef ARENA_DEFAULT_ALIGNMENT
     #define ARENA_DEFAULT_ALIGNMENT ARENA_ALIGNOF(size_t)
 #endif
+
 
 #ifdef ARENA_DEBUG
 

--- a/arena.h
+++ b/arena.h
@@ -106,7 +106,7 @@ specified arena's region. Nothing will restrict you
 from allocating more memory than you specified, so be
 mindful of your memory (as you should anyways) or you
 will get some hard-to-track bugs. By default, memory is
-aligned by sizeof(size_t), but you can change this by
+aligned by alignof(size_t), but you can change this by
 #defining ARENA_DEFAULT_ALIGNMENT before #include'ing
 arena.h. Providing a size of zero results in a failure.
 

--- a/arena.h
+++ b/arena.h
@@ -286,7 +286,6 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
         arena->index = arena->index - offset + alignment;
     }
 
-
     #ifdef ARENA_DEBUG
 
     if(arena->head_allocation == NULL)

--- a/arena.h
+++ b/arena.h
@@ -47,9 +47,9 @@ QUICK USAGE:
     #define ARENA_ALIGNOF(type) offsetof(struct { char c; type d; }, d)
 #endif
 
-
-#define ARENA_DEFAULT_ALIGNMENT ARENA_ALIGNOF(size_t)
-
+#ifndef ARENA_DEFAULT_ALIGNMENT
+    #define ARENA_DEFAULT_ALIGNMENT ARENA_ALIGNOF(size_t)
+#endif
 
 #ifdef ARENA_DEBUG
 

--- a/arena.h
+++ b/arena.h
@@ -270,6 +270,10 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
     if(alignment != 0)
     {
         offset = (size_t)(arena->region + arena->index) % alignment;
+        if(offset > 0)
+        {
+            arena->index = arena->index - offset + alignment;
+        }
     }
     else
     {
@@ -279,11 +283,6 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
     if(arena->size - (arena->index + offset) < size)
     {
         return NULL;
-    }
-
-    if(offset > 0)
-    {
-        arena->index = arena->index - offset + alignment;
     }
 
     #ifdef ARENA_DEBUG

--- a/test.c
+++ b/test.c
@@ -3,9 +3,9 @@ Tests are contained in testing suite functions, the forware declarations
 of which are bundled together. A testing suite function should exist for
 each function within `arena.h`, and should be placed relative to where
 the function they are testing is placed in regard to the functions around
-it for both forward declarations, implementations, and `REPORT`s.
+it for both forward declarations, implementations, and `SUITE`s.
 
-After implementing a testing suite, you should use the `REPORT` in
+After implementing a testing suite, you should use the `SUITE` in
 `main()`.
 
 Tests should comply with C89 in order to ensure backwards compaitbility is
@@ -13,34 +13,24 @@ still achievable.
 
 Within the testing suite, the following macros should be used:
 
-TEST_FATAL(exp, desc) | TEST_FATAL should be used whenever a failure
-                        could cause future tests to crash the process.
+TEST_FATAL(exp, desc)     | TEST_FATAL should be used whenever a failure
+                            could cause future tests to crash the process.
+                            If exp evaluates to false (0), the test executable
+                            will abort completely and the desc string will be
+                            printed.
 
-                        EX/ An `arena_create` failing and returning NULL
-                            could cause an access within the test to
-                            segfault.
+                            EX/ An `arena_create` failing and returning NULL
+                                could cause an access within the test to
+                                segfault.
 
-                        ARGS
-                          exp  | The expression being tests. If the `exp`
-                                 evaluates as true, it passes. Otherwise
-                                 it fails and aborts the program and
-                                 prints the `desc`.
-                          desc | The description to be printed on failure.
+TEST_EQUAL(a, b)          | TEST_EQUAL will fail when a != b
 
-TEST_EQUAL(a, b)      | TEST_EQUAL should be used when two things have
-                        equal value. Use whenever possible.
+TEST_NULL(a)              | TEST_NULL will fail when a != NULL
 
-                        ARGS
-                          If a == b, the test passes. Otherwise, it fails and
-                          prints an appropriate failure message.
+TEST_NOT_NULL(a)          | TEST_NOT_NULL will fail when a == NULL
 
-
-TEST(exp, desc)       | TEST is used whenever TEST_EQUAL doesn't fit.
-
-                        ARGS
-                          If `exp` evaluates at true, the test passes.
-                          Otherwise, the test fails and the `desc` is
-                          printed.
+TEST_ARRAY_EQUAL(a, b, s) | TEST_ARRAY_EQUAL will fail if any elements differ
+                            in two arrays a, b that are both of size s
 */
 
 #include "test.h"

--- a/test.c
+++ b/test.c
@@ -83,7 +83,7 @@ void test_arena_create(void)
 
 void test_arena_alloc(void)
 {
-    Arena *arena = arena_create(ARENA_DEFAULT_ALIGNMENT + 13 + sizeof(long) * 3);
+    Arena *arena = arena_create(13 + sizeof(long) * 3);
     char *char_array = arena_alloc(arena, 13);
     long *long_array;
     long expected_long_array[3] = {999, 9999, 99999};

--- a/test.h
+++ b/test.h
@@ -7,10 +7,10 @@
 #include <stdlib.h>
 
 
-static int passed_tests = 0;
-static int total_tests = 0;
-static int temp_passed;
-static int temp_total;
+int passed_tests = 0;
+int total_tests = 0;
+int temp_passed;
+int temp_total;
 
 
 #define REPORT(msg)       fprintf(stderr, "FAILURE: '%s' at %s:%d\n",       msg, __FILE__, __LINE__)

--- a/test.h
+++ b/test.h
@@ -1,0 +1,79 @@
+#ifndef TEST_H
+#define TEST_H
+
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+
+static int passed_tests = 0;
+static int total_tests = 0;
+static int temp_passed;
+static int temp_total;
+
+
+#define REPORT(msg) fprintf(stderr, "FAILURE: '%s' at %s:%d\n", msg, __FILE__, __LINE__)
+#define REPORT_FATAL(msg) fprintf(stderr, "FATAL FAILURE: '%s' at %s:%d\n", msg, __FILE__, __LINE__)
+
+
+#define TEST(exp, msg)      \
+    do                      \
+    {                       \
+        if(!(exp))          \
+        {                   \
+            REPORT(msg);    \
+        }                   \
+        else                \
+        {                   \
+            passed_tests++; \
+        }                   \
+        total_tests++;      \
+    }while(0)
+
+
+#define TEST_FATAL(exp, msg) do{if(!(exp)){REPORT_FATAL(msg);abort();}}while(0)
+
+
+#define TEST_NULL(a)            TEST(a == NULL, #a " is not NULL")
+#define TEST_NOT_NULL(a)        TEST(a != NULL, #a " is NULL")
+#define TEST_EQUAL(a, b)        TEST(a == b, #a " does not equal " #b)
+#define TEST_NOT_EQUAL(a, b)    TEST(a != b, #a " equals " #b)
+#define TEST_STRING_EQUAL(a, b) TEST(strcmp(a, b) == 0, #a " does not equal " #b)
+#define TEST_STRING_NOT_EQUAL   TEST(strcmp(a, b) != 0, #a " equals " #b)
+
+
+#define TEST_ARRAY_EQUAL(a, b, s)                                 \
+    do                                                            \
+    {                                                             \
+        int i;                                                    \
+        int current_difference = total_tests - passed_tests;      \
+        for(i = 0; i < s; i++)                                    \
+        {                                                         \
+            TEST_EQUAL(a[i], b[i]);                               \
+            if(total_tests - passed_tests != current_difference)  \
+            {                                                     \
+                REPORT(#a " does not equal " #b);                 \
+                break;                                            \
+            }                                                     \
+        }                                                         \
+    }while(0)
+
+
+#define SUITE(suite, name)                                                                                       \
+    do                                                                                                           \
+    {                                                                                                            \
+        temp_passed = passed_tests;                                                                              \
+        temp_total = total_tests;                                                                                \
+        suite();                                                                                                 \
+        fprintf(stderr, "Passed %d/%d tests in '%s'\n", passed_tests-temp_passed, total_tests-temp_total, name); \
+    } while(0)
+
+
+#define ARENA_DEBUG
+#define ARENA_IMPLEMENTATION
+#define ARENA_SUPPRESS_MALLOC_WARN
+#include "arena.h"
+
+
+#endif

--- a/test.h
+++ b/test.h
@@ -35,12 +35,12 @@ static int temp_total;
 #define TEST_FATAL(exp, msg) do{if(!(exp)){REPORT_FATAL(msg);abort();}}while(0)
 
 
-#define TEST_NULL(a)            TEST(a == NULL,         #a " is not NULL")
-#define TEST_NOT_NULL(a)        TEST(a != NULL,         #a " is NULL")
-#define TEST_EQUAL(a, b)        TEST(a == b,            #a " does not equal " #b)
-#define TEST_NOT_EQUAL(a, b)    TEST(a != b,            #a " equals "         #b)
-#define TEST_STRING_EQUAL(a, b) TEST(strcmp(a, b) == 0, #a " does not equal " #b)
-#define TEST_STRING_NOT_EQUAL   TEST(strcmp(a, b) != 0, #a " equals "         #b)
+#define TEST_NULL(a)                TEST(a == NULL,         #a " is not NULL")
+#define TEST_NOT_NULL(a)            TEST(a != NULL,         #a " is NULL")
+#define TEST_EQUAL(a, b)            TEST(a == b,            #a " does not equal " #b)
+#define TEST_NOT_EQUAL(a, b)        TEST(a != b,            #a " equals "         #b)
+#define TEST_STRING_EQUAL(a, b)     TEST(strcmp(a, b) == 0, #a " does not equal " #b)
+#define TEST_STRING_NOT_EQUAL(a, b) TEST(strcmp(a, b) != 0, #a " equals "         #b)
 
 
 #define TEST_ARRAY_EQUAL(a, b, s)                                 \

--- a/test.h
+++ b/test.h
@@ -38,10 +38,6 @@ int temp_total;
 #define TEST_NULL(a)                TEST(a == NULL,         #a " is not NULL")
 #define TEST_NOT_NULL(a)            TEST(a != NULL,         #a " is NULL")
 #define TEST_EQUAL(a, b)            TEST(a == b,            #a " does not equal " #b)
-#define TEST_NOT_EQUAL(a, b)        TEST(a != b,            #a " equals "         #b)
-#define TEST_STRING_EQUAL(a, b)     TEST(strcmp(a, b) == 0, #a " does not equal " #b)
-#define TEST_STRING_NOT_EQUAL(a, b) TEST(strcmp(a, b) != 0, #a " equals "         #b)
-
 
 #define TEST_ARRAY_EQUAL(a, b, s)                                 \
     do                                                            \

--- a/test.h
+++ b/test.h
@@ -73,6 +73,7 @@ int temp_total;
 #define ARENA_DEBUG
 #define ARENA_IMPLEMENTATION
 #define ARENA_SUPPRESS_MALLOC_WARN
+#define ARENA_DEFAULT_ALIGNMENT 0
 #include "arena.h"
 
 

--- a/test.h
+++ b/test.h
@@ -13,7 +13,7 @@ static int temp_passed;
 static int temp_total;
 
 
-#define REPORT(msg) fprintf(stderr, "FAILURE: '%s' at %s:%d\n", msg, __FILE__, __LINE__)
+#define REPORT(msg)       fprintf(stderr, "FAILURE: '%s' at %s:%d\n",       msg, __FILE__, __LINE__)
 #define REPORT_FATAL(msg) fprintf(stderr, "FATAL FAILURE: '%s' at %s:%d\n", msg, __FILE__, __LINE__)
 
 
@@ -35,12 +35,12 @@ static int temp_total;
 #define TEST_FATAL(exp, msg) do{if(!(exp)){REPORT_FATAL(msg);abort();}}while(0)
 
 
-#define TEST_NULL(a)            TEST(a == NULL, #a " is not NULL")
-#define TEST_NOT_NULL(a)        TEST(a != NULL, #a " is NULL")
-#define TEST_EQUAL(a, b)        TEST(a == b, #a " does not equal " #b)
-#define TEST_NOT_EQUAL(a, b)    TEST(a != b, #a " equals " #b)
+#define TEST_NULL(a)            TEST(a == NULL,         #a " is not NULL")
+#define TEST_NOT_NULL(a)        TEST(a != NULL,         #a " is NULL")
+#define TEST_EQUAL(a, b)        TEST(a == b,            #a " does not equal " #b)
+#define TEST_NOT_EQUAL(a, b)    TEST(a != b,            #a " equals "         #b)
 #define TEST_STRING_EQUAL(a, b) TEST(strcmp(a, b) == 0, #a " does not equal " #b)
-#define TEST_STRING_NOT_EQUAL   TEST(strcmp(a, b) != 0, #a " equals " #b)
+#define TEST_STRING_NOT_EQUAL   TEST(strcmp(a, b) != 0, #a " equals "         #b)
 
 
 #define TEST_ARRAY_EQUAL(a, b, s)                                 \


### PR DESCRIPTION
This update addresses #10 and reworks the testing system to be slightly less terrible.

Two new macros in `arena.h` are introduced. `ARENA_ALIGNOF(type)` allows the user to get the alignment of a type. If C11 is being used, this simply evaluates to `alignof` from `<stdalign.h>`. Otherwise it uses a bit of a hacky workaround with `offsetof(struct { char a; type d }, d)`. By default, the alignment for `arena_alloc` is `ARENA_ALIGNOF(size_t)`. This can be changed with an `#define ARENA_DEFAULT_ALIGNMENT <custom_alignment>` before including `arena.h`.

Testing is now split into two files, a source and header. There are new macros for testing, including `TEST_NULL`, `TEST_NOT_NULL`, `TEST_EQUAL`, and `TEST_ARRAY_EQUAL`, whose definitions are pretty self explanatory.

Documentation has been updated accordingly for all changes. Tests pass and there are no leaks.

Closes #10 