### PR TITLE
Fix double-counting of alignment offset in `arena_alloc_aligned`

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -602,7 +602,7 @@ void* arena_alloc_aligned(Arena *arena, size_t size, unsigned int alignment)
         offset = 0;
     }
 
-    if (arena->size - (arena->index + offset) < size)
+    if (arena->size - arena->index < size)
     {
         return NULL;
     }

--- a/tests.c
+++ b/tests.c
@@ -47,3 +47,18 @@ TEST(arena_alloc_tests, basic)
 	EXPECT_LONG_EQ(arena.index, 8);
 	EXPECT_LONG_EQ(arena.allocations, 1);
 }
+
+
+TEST(arena_alloc_aligned_tests, edge_case_tight_space)
+{
+	char region[30];
+	Arena arena;
+	arena_init(&arena, region, 30);
+	arena.index = 10;
+
+	void *ptr = arena_alloc_aligned(&arena, 14, 16);
+
+	ASSERT_TRUE(ptr != NULL);
+	EXPECT_LONG_EQ(arena.index, 30);
+	EXPECT_LONG_EQ(arena.allocations, 1);
+}


### PR DESCRIPTION
## Summary
Fixes the bug reported in issue #19 where `arena_alloc_aligned` incorrectly reports out-of-memory errors due to double-counting the alignment offset.

## Problem
The function calculates an alignment `offset` and adjusts `arena->index` to the aligned position. However, the space check then adds `offset` to the already-adjusted `arena->index`, effectively counting the alignment padding twice.

**Before:**
```c
if (arena->size - (arena->index + offset) < size) {
    return NULL;
}
```

**After:**
```c
if (arena->size - arena->index < size) {
    return NULL;
}
```

## Changes
- Fixed the space check in `arena_alloc_aligned` to use the already-adjusted `arena->index`
- Added test case `arena_alloc_aligned_tests.edge_case_tight_space` to verify the fix

## Testing
The new test covers the edge case where:
- Alignment adjustment is needed (offset > 0)
- Remaining space is tight but sufficient
- Previously would incorrectly return NULL

Example from test:
- Arena size: 30 bytes
- Current index: 10
- Requested: 14 bytes with 16-byte alignment
- Expected: Align to 16, allocate 14 bytes (total 30)
- Before fix: Would return NULL

All tests pass under valgrind.